### PR TITLE
Keycard InteractingDoor Change

### DIFF
--- a/CustomItemsAPI/EventHandlers/KeyCardItemHandler.cs
+++ b/CustomItemsAPI/EventHandlers/KeyCardItemHandler.cs
@@ -11,15 +11,22 @@ internal sealed class KeyCardItemHandler : CustomEventsHandler
     #region Interact Door
     public override void OnPlayerInteractingDoor(PlayerInteractingDoorEventArgs ev)
     {
-        Item? item = ev.Player.CurrentItem;
-        if (item == null)
+        var keycardItem = ev.Player.Items.FirstOrDefault(x => x.Category == ItemCategory.Keycard);
+
+        if (keycardItem == null)
             return;
-        if (!CustomItems.TryGetCustomItem(item, out CustomKeycardBase customKeyCardBase))
+
+        if (!CustomItems.TryGetCustomItem(keycardItem, out CustomKeycardBase customKeyCardBase))
             return;
+
         TypeWrapper<bool> isAllowedHelper = new(ev.IsAllowed);
         TypeWrapper<bool> canOpenHelper = new(ev.CanOpen);
-        CustomKeycardEvents.OnInteractingDoor(customKeyCardBase, ev.Player, item, ev.Door, canOpenHelper, isAllowedHelper);
-        customKeyCardBase.OnInteractingDoor(ev.Player, item, ev.Door, canOpenHelper, isAllowedHelper);
+
+        bool isHeld = ev.Player.CurrentItem == keycardItem;
+
+        CustomKeycardEvents.OnInteractingDoor(customKeyCardBase, ev.Player, keycardItem, ev.Door, canOpenHelper, isAllowedHelper, isHeld);
+        customKeyCardBase.OnInteractingDoor(ev.Player, keycardItem, ev.Door, canOpenHelper, isAllowedHelper);
+
         ev.IsAllowed = isAllowedHelper.Value;
         ev.CanOpen = canOpenHelper.Value;
     }

--- a/CustomItemsAPI/EventHandlers/KeyCardItemHandler.cs
+++ b/CustomItemsAPI/EventHandlers/KeyCardItemHandler.cs
@@ -12,16 +12,13 @@ internal sealed class KeyCardItemHandler : CustomEventsHandler
     public override void OnPlayerInteractingDoor(PlayerInteractingDoorEventArgs ev)
     {
         var keycardItem = ev.Player.Items.FirstOrDefault(x => x.Category == ItemCategory.Keycard);
-
         if (keycardItem == null)
             return;
-
         if (!CustomItems.TryGetCustomItem(keycardItem, out CustomKeycardBase customKeyCardBase))
             return;
 
         TypeWrapper<bool> isAllowedHelper = new(ev.IsAllowed);
         TypeWrapper<bool> canOpenHelper = new(ev.CanOpen);
-
         bool isHeld = ev.Player.CurrentItem == keycardItem;
 
         CustomKeycardEvents.OnInteractingDoor(customKeyCardBase, ev.Player, keycardItem, ev.Door, canOpenHelper, isAllowedHelper, isHeld);

--- a/CustomItemsAPI/EventHandlers/KeyCardItemHandler.cs
+++ b/CustomItemsAPI/EventHandlers/KeyCardItemHandler.cs
@@ -11,21 +11,21 @@ internal sealed class KeyCardItemHandler : CustomEventsHandler
     #region Interact Door
     public override void OnPlayerInteractingDoor(PlayerInteractingDoorEventArgs ev)
     {
-        var keycardItem = ev.Player.Items.FirstOrDefault(x => x.Category == ItemCategory.Keycard);
-        if (keycardItem == null)
-            return;
-        if (!CustomItems.TryGetCustomItem(keycardItem, out CustomKeycardBase customKeyCardBase))
-            return;
+        foreach (var keycardItem in ev.Player.Items.Where(x => x.Category == ItemCategory.Keycard))
+        {
+            if (!CustomItems.TryGetCustomItem(keycardItem, out CustomKeycardBase customKeyCardBase))
+                continue;
 
-        TypeWrapper<bool> isAllowedHelper = new(ev.IsAllowed);
-        TypeWrapper<bool> canOpenHelper = new(ev.CanOpen);
-        bool isHeld = ev.Player.CurrentItem == keycardItem;
+            TypeWrapper<bool> isAllowedHelper = new(ev.IsAllowed);
+            TypeWrapper<bool> canOpenHelper = new(ev.CanOpen);
+            bool isHeld = ev.Player.CurrentItem == keycardItem;
 
-        CustomKeycardEvents.OnInteractingDoor(customKeyCardBase, ev.Player, keycardItem, ev.Door, canOpenHelper, isAllowedHelper, isHeld);
-        customKeyCardBase.OnInteractingDoor(ev.Player, keycardItem, ev.Door, canOpenHelper, isAllowedHelper);
+            CustomKeycardEvents.OnInteractingDoor(customKeyCardBase, ev.Player, keycardItem, ev.Door, canOpenHelper, isAllowedHelper, isHeld);
+            customKeyCardBase.OnInteractingDoor(ev.Player, keycardItem, ev.Door, canOpenHelper, isAllowedHelper);
 
-        ev.IsAllowed = isAllowedHelper.Value;
-        ev.CanOpen = canOpenHelper.Value;
+            ev.IsAllowed = isAllowedHelper.Value;
+            ev.CanOpen = canOpenHelper.Value;
+        }
     }
 
     public override void OnPlayerInteractedDoor(PlayerInteractedDoorEventArgs ev)

--- a/CustomItemsAPI/Events/CustomKeycardEvents.cs
+++ b/CustomItemsAPI/Events/CustomKeycardEvents.cs
@@ -7,7 +7,7 @@ namespace CustomItemsAPI.Events;
 public static class CustomKeycardEvents
 {
     public static event Action<CustomKeycardBase, Player, Item, Door, bool>? InteractedDoor;
-    public static event Action<CustomKeycardBase, Player, Item, Door, TypeWrapper<bool>, TypeWrapper<bool>>? InteractingDoor;
+    public static event Action<CustomKeycardBase, Player, Item, Door, TypeWrapper<bool>, TypeWrapper<bool>, bool>? InteractingDoor;
     public static event Action<CustomKeycardBase, Player, Item, Generator, GeneratorColliderId>? InteractedGenerator;
     public static event Action<CustomKeycardBase, Player, Item, Generator, TypeWrapper<GeneratorColliderId>, TypeWrapper<bool>>? InteractingGenerator;
     public static event Action<CustomKeycardBase, Player, Item, Locker, LockerChamber, bool>? InteractedLocker;

--- a/CustomItemsAPI/Events/CustomKeycardEvents.cs
+++ b/CustomItemsAPI/Events/CustomKeycardEvents.cs
@@ -17,8 +17,8 @@ public static class CustomKeycardEvents
 
     public static void OnInteractedDoor(CustomKeycardBase customItem, Player player, Item item, Door door, bool canOpen)
         => InteractedDoor?.Invoke(customItem, player, item, door, canOpen);
-    public static void OnInteractingDoor(CustomKeycardBase customItem, Player player, Item item, Door door, TypeWrapper<bool> canOpen, TypeWrapper<bool> isAllowed)
-        => InteractingDoor?.Invoke(customItem, player, item, door, canOpen, isAllowed);
+    public static void OnInteractingDoor(CustomKeycardBase customItem, Player player, Item item, Door door, TypeWrapper<bool> canOpen, TypeWrapper<bool> isAllowed, bool isHeld)
+        => InteractingDoor?.Invoke(customItem, player, item, door, canOpen, isAllowed, isHeld);
     public static void OnInteractedGenerator(CustomKeycardBase customItem, Player player, Item item, Generator generator, GeneratorColliderId colliderId)
         => InteractedGenerator?.Invoke(customItem, player, item, generator, colliderId);
     public static void OnInteractingGenerator(CustomKeycardBase customItem, Player player, Item item, Generator generator, TypeWrapper<GeneratorColliderId> colliderId, TypeWrapper<bool> isAllowed)


### PR DESCRIPTION
change KeyCardItemHandler to invoke the interaction of the door no matter the state of whether the item is held or not by checking inventory for all keycards 

add on CustomKeycardEvents to add another peram "IsHeld" to specify whether the custom keycard in question is held currently by the player or is just in their inventory to cover the change in call state 